### PR TITLE
fix: to read the weights and bias from the VGG Mat file

### DIFF
--- a/art.py
+++ b/art.py
@@ -141,9 +141,9 @@ def load_vgg_model(path):
         """
         Return the weights and bias from the VGG model for a given layer.
         """
-        W = vgg_layers[0][layer][0][0][0][0][0]
-        b = vgg_layers[0][layer][0][0][0][0][1]
-        layer_name = vgg_layers[0][layer][0][0][-2]
+        W = vgg_layers[0][layer][0][0][2][0][0]
+        b = vgg_layers[0][layer][0][0][2][0][1]
+        layer_name = vgg_layers[0][layer][0][0][0][0]
         assert layer_name == expected_layer_name
         return W, b
 


### PR DESCRIPTION
dunno if the ordering of scipy.io.loadmat(path) is machine dependent or not. Here is what I have changed to make it runs on my machine.
