### PR TITLE
Update

### DIFF
--- a/art.py
+++ b/art.py
@@ -141,9 +141,9 @@ def load_vgg_model(path):
         """
         Return the weights and bias from the VGG model for a given layer.
         """
-        W = vgg_layers[0][layer][0][0][0][0][0]
-        b = vgg_layers[0][layer][0][0][0][0][1]
-        layer_name = vgg_layers[0][layer][0][0][-2]
+        W = vgg_layers[0][layer][0][0][2][0][0]
+        b = vgg_layers[0][layer][0][0][2][0][1]
+        layer_name = vgg_layers[0][layer][0][0][0]
         assert layer_name == expected_layer_name
         return W, b
 
@@ -161,7 +161,7 @@ def load_vgg_model(path):
         """
         W, b = _weights(layer, layer_name)
         W = tf.constant(W)
-        b = tf.constant(np.reshape(b, (b.size)))
+        b = tf.constant(b.T)
         return tf.nn.conv2d(
             prev_layer, filter=W, strides=[1, 1, 1, 1], padding='SAME') + b
 


### PR DESCRIPTION
Without changing these indexes, the program will meet some errors.I think this may be caused by the change of VGG model downloaded from the website mentioned in READMD.md or something else like this.What's more,b = vgg_layers[0][layer][0][0][2][0][1] will return a numpy.ndarray of shape (1,None),so I decided to use b = tf.constant(b.T) in the code.
Here is my test code to find out what vgg_layers looks like:
>>> VGG_MODEL = 'imagenet-vgg-verydeep-19.mat'
>>> vgg = scipy.io.loadmat(VGG_MODEL)
>>> vgg_layers = vgg['layers']
>>> vgg_layers[0][0][0][0][-2]
array([[1]], dtype=uint8)
>>> vgg_layers[0][0][0][0][0][0][0]
'c'
>>> vgg_layers[0][0][0][0][0][0][1]
'o'
>>> vgg_layers[0][0][0][0][2][0][0].shape
(3, 3, 3, 64)
>>> vgg_layers[0][0][0][0][2][0][1].shape
(64, 1)
>>>